### PR TITLE
게시글에 Markdown 기능과 테스트 페이지를 추가했습니다.

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,12 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@tailwindcss/vite": "^4.1.11",
+				"@tiptap/extension-color": "^2.25.0",
+				"@tiptap/extension-highlight": "^2.25.0",
+				"@tiptap/extension-list-item": "^2.25.0",
+				"@tiptap/extension-placeholder": "^2.25.0",
+				"@tiptap/extension-typography": "^2.25.0",
+				"@tiptap/starter-kit": "^2.25.0",
 				"highlight.js": "^11.11.1"
 			},
 			"devDependencies": {
@@ -499,6 +505,12 @@
 			"resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
 			"integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@remirror/core-constants": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-3.0.0.tgz",
+			"integrity": "sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==",
 			"license": "MIT"
 		},
 		"node_modules/@rollup/rollup-android-arm-eabi": {
@@ -1116,6 +1128,388 @@
 				"vite": "^5.2.0 || ^6 || ^7"
 			}
 		},
+		"node_modules/@tiptap/core": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.25.0.tgz",
+			"integrity": "sha512-pTLV0+g+SBL49/Y5A9ii7oHwlzIzpgroJVI3AcBk7/SeR7554ZzjxxtJmZkQ9/NxJO+k1jQp9grXaqqOLqC7cA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/pm": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-blockquote": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-2.25.0.tgz",
+			"integrity": "sha512-W+sVPlV9XmaNPUkxV2BinNEbk2hr4zw8VgKjqKQS9O0k2YIVRCfQch+4DudSAwBVMrVW97zVAKRNfictGFQ8vQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-bold": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-2.25.0.tgz",
+			"integrity": "sha512-3cBX2EtdFR3+EDTkIshhpQpXoZQbFUzxf6u86Qm0qD49JnVOjX9iexnUp8MydXPZA6NVsKeEfMhf18gV7oxTEw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-bullet-list": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-2.25.0.tgz",
+			"integrity": "sha512-KD+q/q6KIU2anedjtjG8vELkL5rYFdNHWc5XcUJgQoxbOCK3/sBuOgcn9mnFA2eAS6UkraN9Yx0BXEDbXX2HOw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-code": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-2.25.0.tgz",
+			"integrity": "sha512-rRp6X2aNNnvo7Fbqc3olZ0vLb52FlCPPfetr9gy6/M9uQdVYDhJcFOPuRuXtZ8M8X+WpCZBV29BvZFeDqfw8bw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-code-block": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.25.0.tgz",
+			"integrity": "sha512-T4kXbZNZ/NyklzQ/FWmUnjD4hgmJPrIBazzCZ/E/rF/Ag2IvUsztBT0PN3vTa+DAZ+IbM61TjlIpyJs1R7OdbQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0",
+				"@tiptap/pm": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-color": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-color/-/extension-color-2.25.0.tgz",
+			"integrity": "sha512-jZh7X71Kd8TVU/lexbosyeBseOj2jzxQ5/7DV/L6E2SHsXX9rIOeY61kf4xRqoQm5Z9t2vy8GzNGXhhNACd66w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0",
+				"@tiptap/extension-text-style": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-document": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-2.25.0.tgz",
+			"integrity": "sha512-3gEZlQKUSIRrC6Az8QS7SJi4CvhMWrA7RBChM1aRl9vMNN8Ul7dZZk5StYJGPjL/koTiceMqx9pNmTCBprsbvQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-dropcursor": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-2.25.0.tgz",
+			"integrity": "sha512-eSHqp+iUI2mGVwvIyENP02hi5TSyQ+bdwNwIck6bdzjRvXakm72+8uPfVSLGxRKAQZ0RFtmux8ISazgUqF/oSw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0",
+				"@tiptap/pm": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-gapcursor": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-2.25.0.tgz",
+			"integrity": "sha512-s/3WDbgkvLac88h5iYJLPJCDw8tMhlss1hk9GAo+zzP4h0xfazYie09KrA0CBdfaSOFyeJK3wedzjKZBtdgX4w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0",
+				"@tiptap/pm": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-hard-break": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-2.25.0.tgz",
+			"integrity": "sha512-h8be5Zdtsl5GQHxRXvYlGfIJsLvdbexflSTr12gr4kvcQqTdtrsqyu2eksfAK+p2szbiwP2G4VZlH0LNS47UXQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-heading": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-2.25.0.tgz",
+			"integrity": "sha512-IrRKRRr7Bhpnq5aue1v5/e5N/eNdVV/THsgqqpLZO48pgN8Wv+TweOZe1Ntg/v8L4QSBC8iGMxxhiJZT8AzSkA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-highlight": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-highlight/-/extension-highlight-2.25.0.tgz",
+			"integrity": "sha512-YuDZUFTil06wmuIMod1z2zbLGIwDwcoRV21f2wZBl3SryzppX/B1S1fGgLdnOo4M8ryykSKxWdpjMSOYCAdsjA==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-history": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-history/-/extension-history-2.25.0.tgz",
+			"integrity": "sha512-y3uJkJv+UngDaDYfcVJ4kx8ivc3Etk5ow6N+47AMCRjUUweQ/CLiJwJ2C7nL7L82zOzVbb/NoR/B3UeE4ts/wQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0",
+				"@tiptap/pm": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-horizontal-rule": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-2.25.0.tgz",
+			"integrity": "sha512-bZovyhdOexB3Cv9ddUogWT+cd3KbnenMIZKhgrJ+R0J27rlOtzeUD9TeIjn4V8Of9mTxm3XDKUZGLgPiriN8Ww==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0",
+				"@tiptap/pm": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-italic": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-2.25.0.tgz",
+			"integrity": "sha512-FZHmNqvWJ5SHYlUi+Qg3b2C0ZBt82DUDUqM+bqcQqSQu6B0c4IEc3+VHhjAJwEUIO9wX7xk/PsdM4Z5Ex4Lr3w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-list-item": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-2.25.0.tgz",
+			"integrity": "sha512-HLstO/R+dNjIFMXN15bANc8i/+CDpEgtEQhZNHqvSUJH9xQ5op0S05m5VvFI10qnwXNjwwXdhxUYwwjIDCiAgg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-ordered-list": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-2.25.0.tgz",
+			"integrity": "sha512-Hlid16nQdDFOGOx6mJT+zPEae2t1dGlJ18pqCqaVMuDnIpNIWmQutJk5QYxGVxr9awd2SpHTpQtdBTqcufbHtw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-paragraph": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-2.25.0.tgz",
+			"integrity": "sha512-53gpWMPedkWVDp3u/1sLt6vnr3BWz4vArGCmmabLucCI2Yl4R6S/AQ9yj/+jOHvWbXCroCbKtmmwxJl32uGN2w==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-placeholder": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-2.25.0.tgz",
+			"integrity": "sha512-BUJnp/WQt/8iMJ9wn1xGlA+RiXCsP24u5n+ecxw+DBTgFq7RRL9I1nDQ/IJBrfWMJGOrMEq6tg8rmg1NVLGfWw==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0",
+				"@tiptap/pm": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-strike": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-2.25.0.tgz",
+			"integrity": "sha512-Z5YBKnv4N6MMD1LEo9XbmWnmdXavZKOOJt/OkXYFZ3KgzB52Z3q3DDfH+NyeCtKKSWqWVxbBHKLnsojDerSf2g==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-text": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-2.25.0.tgz",
+			"integrity": "sha512-HlZL86rihpP/R8+dqRrvzSRmiPpx6ctlAKM9PnWT/WRMeI4Y1AUq6PSHLz74wtYO1LH4PXys1ws3n+pLP4Mo6g==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-text-style": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-text-style/-/extension-text-style-2.25.0.tgz",
+			"integrity": "sha512-MKAXqDATEbuFEB1SeeAFy2VbefUMJ9jxQyybpaHjDX+Ik0Ddu+aYuJP/njvLuejXCqhrkS/AorxzmHUC4HNPbQ==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/extension-typography": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/extension-typography/-/extension-typography-2.25.0.tgz",
+			"integrity": "sha512-FvKWj/ebpwmPFGKrGjJ9/If/++PCJHJ5GQZuUgV4YzHpdskpFIcs7jJaC/GdFBe+NY+8bW1s8oBY1mihERImQg==",
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			},
+			"peerDependencies": {
+				"@tiptap/core": "^2.7.0"
+			}
+		},
+		"node_modules/@tiptap/pm": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.25.0.tgz",
+			"integrity": "sha512-vuzU0pLGQyHqtikAssHn9V61aXLSQERQtn3MUtaJ36fScQg7RClAK5gnIbBt3Ul3VFof8o4xYmcidARc0X/E5A==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-changeset": "^2.3.0",
+				"prosemirror-collab": "^1.3.1",
+				"prosemirror-commands": "^1.6.2",
+				"prosemirror-dropcursor": "^1.8.1",
+				"prosemirror-gapcursor": "^1.3.2",
+				"prosemirror-history": "^1.4.1",
+				"prosemirror-inputrules": "^1.4.0",
+				"prosemirror-keymap": "^1.2.2",
+				"prosemirror-markdown": "^1.13.1",
+				"prosemirror-menu": "^1.2.4",
+				"prosemirror-model": "^1.23.0",
+				"prosemirror-schema-basic": "^1.2.3",
+				"prosemirror-schema-list": "^1.4.1",
+				"prosemirror-state": "^1.4.3",
+				"prosemirror-tables": "^1.6.4",
+				"prosemirror-trailing-node": "^3.0.0",
+				"prosemirror-transform": "^1.10.2",
+				"prosemirror-view": "^1.37.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			}
+		},
+		"node_modules/@tiptap/starter-kit": {
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-2.25.0.tgz",
+			"integrity": "sha512-MWt6gEdQ2LPuCqbvNGmS0uA+6rtMGRh3vC0WBNp6rJPAvwS8OPcpraLz61cWjgzeKZBUKODpNA5IZ6gDRyH9LQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@tiptap/core": "^2.25.0",
+				"@tiptap/extension-blockquote": "^2.25.0",
+				"@tiptap/extension-bold": "^2.25.0",
+				"@tiptap/extension-bullet-list": "^2.25.0",
+				"@tiptap/extension-code": "^2.25.0",
+				"@tiptap/extension-code-block": "^2.25.0",
+				"@tiptap/extension-document": "^2.25.0",
+				"@tiptap/extension-dropcursor": "^2.25.0",
+				"@tiptap/extension-gapcursor": "^2.25.0",
+				"@tiptap/extension-hard-break": "^2.25.0",
+				"@tiptap/extension-heading": "^2.25.0",
+				"@tiptap/extension-history": "^2.25.0",
+				"@tiptap/extension-horizontal-rule": "^2.25.0",
+				"@tiptap/extension-italic": "^2.25.0",
+				"@tiptap/extension-list-item": "^2.25.0",
+				"@tiptap/extension-ordered-list": "^2.25.0",
+				"@tiptap/extension-paragraph": "^2.25.0",
+				"@tiptap/extension-strike": "^2.25.0",
+				"@tiptap/extension-text": "^2.25.0",
+				"@tiptap/extension-text-style": "^2.25.0",
+				"@tiptap/pm": "^2.25.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/ueberdosis"
+			}
+		},
 		"node_modules/@types/cookie": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
@@ -1127,6 +1521,28 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"license": "MIT"
+		},
+		"node_modules/@types/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+			"license": "MIT"
+		},
+		"node_modules/@types/markdown-it": {
+			"version": "14.1.2",
+			"resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+			"integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/linkify-it": "^5",
+				"@types/mdurl": "^2"
+			}
+		},
+		"node_modules/@types/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
@@ -1141,6 +1557,12 @@
 			"engines": {
 				"node": ">=0.4.0"
 			}
+		},
+		"node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"license": "Python-2.0"
 		},
 		"node_modules/aria-query": {
 			"version": "5.3.2",
@@ -1207,6 +1629,12 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/crelt": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"license": "MIT"
+		},
 		"node_modules/debug": {
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
@@ -1264,6 +1692,18 @@
 				"node": ">=10.13.0"
 			}
 		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
+			}
+		},
 		"node_modules/esbuild": {
 			"version": "0.25.5",
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
@@ -1302,6 +1742,18 @@
 				"@esbuild/win32-arm64": "0.25.5",
 				"@esbuild/win32-ia32": "0.25.5",
 				"@esbuild/win32-x64": "0.25.5"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/esm-env": {
@@ -1621,6 +2073,15 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -1636,6 +2097,29 @@
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0"
 			}
+		},
+		"node_modules/markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"license": "MIT"
 		},
 		"node_modules/minipass": {
 			"version": "7.1.2",
@@ -1718,6 +2202,12 @@
 				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
 			}
 		},
+		"node_modules/orderedmap": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+			"integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
+			"license": "MIT"
+		},
 		"node_modules/picocolors": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1762,6 +2252,210 @@
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
+			}
+		},
+		"node_modules/prosemirror-changeset": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.3.1.tgz",
+			"integrity": "sha512-j0kORIBm8ayJNl3zQvD1TTPHJX3g042et6y/KQhZhnPrruO8exkTgG8X+NRpj7kIyMMEx74Xb3DyMIBtO0IKkQ==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-transform": "^1.0.0"
+			}
+		},
+		"node_modules/prosemirror-collab": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-collab/-/prosemirror-collab-1.3.1.tgz",
+			"integrity": "sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-state": "^1.0.0"
+			}
+		},
+		"node_modules/prosemirror-commands": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+			"integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-model": "^1.0.0",
+				"prosemirror-state": "^1.0.0",
+				"prosemirror-transform": "^1.10.2"
+			}
+		},
+		"node_modules/prosemirror-dropcursor": {
+			"version": "1.8.2",
+			"resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+			"integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-state": "^1.0.0",
+				"prosemirror-transform": "^1.1.0",
+				"prosemirror-view": "^1.1.0"
+			}
+		},
+		"node_modules/prosemirror-gapcursor": {
+			"version": "1.3.2",
+			"resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.3.2.tgz",
+			"integrity": "sha512-wtjswVBd2vaQRrnYZaBCbyDqr232Ed4p2QPtRIUK5FuqHYKGWkEwl08oQM4Tw7DOR0FsasARV5uJFvMZWxdNxQ==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-keymap": "^1.0.0",
+				"prosemirror-model": "^1.0.0",
+				"prosemirror-state": "^1.0.0",
+				"prosemirror-view": "^1.0.0"
+			}
+		},
+		"node_modules/prosemirror-history": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.4.1.tgz",
+			"integrity": "sha512-2JZD8z2JviJrboD9cPuX/Sv/1ChFng+xh2tChQ2X4bB2HeK+rra/bmJ3xGntCcjhOqIzSDG6Id7e8RJ9QPXLEQ==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-state": "^1.2.2",
+				"prosemirror-transform": "^1.0.0",
+				"prosemirror-view": "^1.31.0",
+				"rope-sequence": "^1.3.0"
+			}
+		},
+		"node_modules/prosemirror-inputrules": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/prosemirror-inputrules/-/prosemirror-inputrules-1.5.0.tgz",
+			"integrity": "sha512-K0xJRCmt+uSw7xesnHmcn72yBGTbY45vm8gXI4LZXbx2Z0jwh5aF9xrGQgrVPu0WbyFVFF3E/o9VhJYz6SQWnA==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-state": "^1.0.0",
+				"prosemirror-transform": "^1.0.0"
+			}
+		},
+		"node_modules/prosemirror-keymap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+			"integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-state": "^1.0.0",
+				"w3c-keyname": "^2.2.0"
+			}
+		},
+		"node_modules/prosemirror-markdown": {
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.2.tgz",
+			"integrity": "sha512-FPD9rHPdA9fqzNmIIDhhnYQ6WgNoSWX9StUZ8LEKapaXU9i6XgykaHKhp6XMyXlOWetmaFgGDS/nu/w9/vUc5g==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/markdown-it": "^14.0.0",
+				"markdown-it": "^14.0.0",
+				"prosemirror-model": "^1.25.0"
+			}
+		},
+		"node_modules/prosemirror-menu": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/prosemirror-menu/-/prosemirror-menu-1.2.5.tgz",
+			"integrity": "sha512-qwXzynnpBIeg1D7BAtjOusR+81xCp53j7iWu/IargiRZqRjGIlQuu1f3jFi+ehrHhWMLoyOQTSRx/IWZJqOYtQ==",
+			"license": "MIT",
+			"dependencies": {
+				"crelt": "^1.0.0",
+				"prosemirror-commands": "^1.0.0",
+				"prosemirror-history": "^1.0.0",
+				"prosemirror-state": "^1.0.0"
+			}
+		},
+		"node_modules/prosemirror-model": {
+			"version": "1.25.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.1.tgz",
+			"integrity": "sha512-AUvbm7qqmpZa5d9fPKMvH1Q5bqYQvAZWOGRvxsB6iFLyycvC9MwNemNVjHVrWgjaoxAfY8XVg7DbvQ/qxvI9Eg==",
+			"license": "MIT",
+			"dependencies": {
+				"orderedmap": "^2.0.0"
+			}
+		},
+		"node_modules/prosemirror-schema-basic": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/prosemirror-schema-basic/-/prosemirror-schema-basic-1.2.4.tgz",
+			"integrity": "sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-model": "^1.25.0"
+			}
+		},
+		"node_modules/prosemirror-schema-list": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+			"integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-model": "^1.0.0",
+				"prosemirror-state": "^1.0.0",
+				"prosemirror-transform": "^1.7.3"
+			}
+		},
+		"node_modules/prosemirror-state": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.3.tgz",
+			"integrity": "sha512-goFKORVbvPuAQaXhpbemJFRKJ2aixr+AZMGiquiqKxaucC6hlpHNZHWgz5R7dS4roHiwq9vDctE//CZ++o0W1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-model": "^1.0.0",
+				"prosemirror-transform": "^1.0.0",
+				"prosemirror-view": "^1.27.0"
+			}
+		},
+		"node_modules/prosemirror-tables": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.7.1.tgz",
+			"integrity": "sha512-eRQ97Bf+i9Eby99QbyAiyov43iOKgWa7QCGly+lrDt7efZ1v8NWolhXiB43hSDGIXT1UXgbs4KJN3a06FGpr1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-keymap": "^1.2.2",
+				"prosemirror-model": "^1.25.0",
+				"prosemirror-state": "^1.4.3",
+				"prosemirror-transform": "^1.10.3",
+				"prosemirror-view": "^1.39.1"
+			}
+		},
+		"node_modules/prosemirror-trailing-node": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-3.0.0.tgz",
+			"integrity": "sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@remirror/core-constants": "3.0.0",
+				"escape-string-regexp": "^4.0.0"
+			},
+			"peerDependencies": {
+				"prosemirror-model": "^1.22.1",
+				"prosemirror-state": "^1.4.2",
+				"prosemirror-view": "^1.33.8"
+			}
+		},
+		"node_modules/prosemirror-transform": {
+			"version": "1.10.4",
+			"resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.10.4.tgz",
+			"integrity": "sha512-pwDy22nAnGqNR1feOQKHxoFkkUtepoFAd3r2hbEDsnf4wp57kKA36hXsB3njA9FtONBEwSDnDeCiJe+ItD+ykw==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-model": "^1.21.0"
+			}
+		},
+		"node_modules/prosemirror-view": {
+			"version": "1.40.0",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.40.0.tgz",
+			"integrity": "sha512-2G3svX0Cr1sJjkD/DYWSe3cfV5VPVTBOxI9XQEGWJDFEpsZb/gh4MV29ctv+OJx2RFX4BLt09i+6zaGM/ldkCw==",
+			"license": "MIT",
+			"dependencies": {
+				"prosemirror-model": "^1.20.0",
+				"prosemirror-state": "^1.0.0",
+				"prosemirror-transform": "^1.1.0"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/readdirp": {
@@ -1816,6 +2510,12 @@
 				"@rollup/rollup-win32-x64-msvc": "4.44.1",
 				"fsevents": "~2.3.2"
 			}
+		},
+		"node_modules/rope-sequence": {
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+			"integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
+			"license": "MIT"
 		},
 		"node_modules/sade": {
 			"version": "1.8.1",
@@ -1983,6 +2683,12 @@
 				"node": ">=14.17"
 			}
 		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"license": "MIT"
+		},
 		"node_modules/vite": {
 			"version": "6.3.5",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
@@ -2075,6 +2781,12 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/w3c-keyname": {
+			"version": "2.2.8",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+			"license": "MIT"
 		},
 		"node_modules/yallist": {
 			"version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,12 @@
 	},
 	"dependencies": {
 		"@tailwindcss/vite": "^4.1.11",
+		"@tiptap/extension-color": "^2.25.0",
+		"@tiptap/extension-highlight": "^2.25.0",
+		"@tiptap/extension-list-item": "^2.25.0",
+		"@tiptap/extension-placeholder": "^2.25.0",
+		"@tiptap/extension-typography": "^2.25.0",
+		"@tiptap/starter-kit": "^2.25.0",
 		"highlight.js": "^11.11.1"
 	}
 }

--- a/frontend/src/lib/components/postPreview.svelte
+++ b/frontend/src/lib/components/postPreview.svelte
@@ -1,5 +1,11 @@
 <script lang='ts'>
   export let data: App.PostData
+
+  const stripHtmlFast = (html: string) => {
+    return html.replace(/<[^>]*>/g, '')
+  }
+
+  const summary = stripHtmlFast(data.post_content.slice(0,128)) + "..."
 </script>
 
 <a href={`/board/`+data.post_id} class="m-1">
@@ -9,6 +15,6 @@
       <p class="text-sm text-gray-400">{data.post_uploader.user_name} | {data.post_createdDate}</p>
       <p class="text-gray-400"> {data.post_id}</p>
     </div>
-    <p class="border-t-1 border-neutral-600 text-neutral-500 ">{data.post_content}</p>
+    <p class="border-t-1 border-neutral-600 text-neutral-500 ">{stripHtmlFast(summary)}</p>
   </div>
 </a>

--- a/frontend/src/lib/components/tiptap/tiptap.css
+++ b/frontend/src/lib/components/tiptap/tiptap.css
@@ -1,0 +1,116 @@
+@import "tailwindcss";
+
+@layer components{
+  .tiptap:first-child {
+    margin-top: 0;
+  }
+
+  /* List styles */
+  .tiptap ul,
+  .tiptap ol {
+    padding: 0 1rem;
+    margin: 0.25rem 1rem 0.25rem 0.4rem;
+  }
+
+  .tiptap ul {
+    list-style-type: disc;
+  }
+  .tiptap ol {
+    list-style-type: decimal;
+  }
+
+  .tiptap ul li p,
+  .tiptap ol li p {
+    margin-top: 0.25em;
+    margin-bottom: 0.25em;
+  }
+
+  /* Heading styles */
+  .tiptap h1,
+  .tiptap h2,
+  .tiptap h3,
+  .tiptap h4,
+  .tiptap h5,
+  .tiptap h6 {
+    line-height: 1.1;
+    margin-top: 1.2rem;
+    text-wrap: pretty;
+
+    @apply font-bold;
+  }
+
+  .tiptap h1,
+  .tiptap h2 {
+    margin-top: 1rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .tiptap h1 {
+    font-size: 2.3rem;
+  }
+
+  .tiptap h2 {
+    font-size: 1.8rem;
+  }
+
+  .tiptap h3 {
+    font-size: 1.4rem;
+  }
+
+  .tiptap h4,
+  .tiptap h5,
+  .tiptap h6 {
+    font-size: 1.2rem;
+  }
+
+  /* Code and preformatted text styles */
+  .tiptap code {
+    @apply bg-purple-200;
+    border-radius: 0.4rem;
+    @apply text-black;
+    font-size: 0.85rem;
+    padding: 0.25em 0.3em;
+  }
+
+  .tiptap pre {
+    @apply bg-black;
+    border-radius: 0.5rem;
+    @apply text-white;
+    font-family: 'JetBrainsMono', monospace;
+    @apply py-0;
+    /*margin: 0rem 0;
+    padding: 0.75rem 0.25rem;*/
+    @apply overflow-x-scroll
+  }
+
+  .tiptap pre code {
+    background: none;
+    color: inherit;
+    font-size: 0.8rem;
+    padding: 0;
+  }
+
+  /* Blockquote */
+  .tiptap blockquote {
+    border-left: 3px solid;
+    @apply border-gray-300;
+    margin: 1.5rem 0;
+    padding-left: 1rem;
+  }
+
+  /* Horizontal rule */
+  .tiptap hr {
+    border: none;
+    border-top: 1px solid;
+    @apply border-gray-200;
+    margin: 2rem 0;
+  }
+
+  .tiptap .is-editor-empty:first-child::before {
+    @apply text-gray-400;
+    content: attr(data-placeholder);
+    float: left;
+    height: 0;
+    pointer-events: none;
+  }
+}

--- a/frontend/src/lib/components/tiptap/tiptap.svelte
+++ b/frontend/src/lib/components/tiptap/tiptap.svelte
@@ -1,0 +1,44 @@
+<script>
+  import "./tiptap.css"
+
+  import Placeholder from '@tiptap/extension-placeholder'
+  import Highlight from '@tiptap/extension-highlight'
+  import Typography from '@tiptap/extension-typography'
+  import StarterKit from "@tiptap/starter-kit"
+  import { Editor } from "@tiptap/core"
+  import { onMount } from "svelte"
+
+  let element
+  let editor
+  const placeholder = `내용을 입력하세요...
+markdown 문법 또한
+부분적으로 사용 가능합니다...`
+  export let className = ""
+  export let content = ""
+
+  onMount(() => {
+    editor = new Editor({
+      element: element,
+      extensions: [
+        StarterKit,
+        Highlight,
+        Typography,
+        Placeholder.configure({
+          placeholder: placeholder,          
+        }),
+      ],
+      editorProps: {
+        attributes: {
+          class: `tiptap ${className}`
+        }
+      }
+      ,
+      content,
+      onUpdate({ editor }) {
+        content = editor.getHTML();
+      }
+    })
+  })
+</script>
+
+<div bind:this={element}></div>

--- a/frontend/src/lib/testPostData.ts
+++ b/frontend/src/lib/testPostData.ts
@@ -1,0 +1,41 @@
+export const testPostData: App.PostData = {
+  post_code:`public class Main {
+    public static void main (String[] args) {
+      System.out.println("Hello, World!!");
+    }
+  }`,
+    post_createdDate: "0000.00.00/00:00",
+  
+    post_id: -1,
+    post_title: "테스트 페이지입니다.",
+    post_uploader: {
+      user_createDate: "0000.00.00/00:00",
+      user_id: 0,
+      user_name: "테스트 유저",
+      user_role: 7,
+    },
+    post_comments: [],
+    post_content: `
+    <p>포스트 내용이 들어갈 위치입니다.</p>
+    <h1>제목도</h1>
+    <h2>들어</h2>
+    <h3>가고</h3>
+    <ul>
+      <li>이런 식으로</li>
+      <li>리스트도 들어갑니다.</li>
+    </ul>
+    <ol>
+      <li>번호도</li>
+      <li>매겨지고요.</li>
+    </ol>
+    
+    <hr/>
+    <blockquote>마크다운 문법은 웬만한건 들어갑니다.</blockquote>
+    <pre>
+      <code>public class Main {
+  public static void main (String[] args) {
+    System.out.println("Hello, World!!");
+  }
+}</code>
+    </pre>`,
+}

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -31,6 +31,7 @@
   {#each posts as post}
     <Postpreview data={post}/>
   {/each}
+  <Postpreview data={testPostData}/>
 </main>
 
 <!-- 페이지네이션 -->
@@ -46,6 +47,7 @@
 
 <script lang="ts">
   import Postpreview from '$lib/components/postPreview.svelte'
+  import { testPostData } from '$lib/testPostData';
   import { onMount } from 'svelte';
 
   let posts: App.PostData[] = []

--- a/frontend/src/routes/board/-1/+page.svelte
+++ b/frontend/src/routes/board/-1/+page.svelte
@@ -1,0 +1,80 @@
+<!-- src/routes/+page.svelte -->
+<div class="flex h-screen">
+  <!-- 왼쪽: 코드 블록 -->
+  <div class="w-1/2 bg-black">
+    <!-- 윗 블럭 -->
+    <div class="flex justify-between bg-white">
+      <p class="py-0.25 px-2 m-1">Java 21</p>
+      <button class="border-1 rounded-sm border-black py-0.25 px-2 m-1">코드 복사</button>
+    </div>
+    <!-- 코드 부분 -->
+    <div class="bg-black text-white p-4 overflow-scroll no-scrollbar font-mono text-sm leading-tight">
+      <table class="table-fixed w-full">
+        <tbody>
+          <!-- 반복 - data.code 줄 만큼 -->
+          {#each (data.post_code ?? "").split('\n') as line, i}
+            <tr>
+              <!-- 코드 번호 -->
+              <td class="pr-4 text-right text-gray-500 select-none w-8 border-r-1 border-neutral-500">{i + 1}</td>
+              <!-- 코드 내용 -->
+              <td class="align-top"><code class="language-java whitespace-pre">{line}</code></td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <!-- 오른쪽: 글 + 댓글 -->
+  <div class="w-1/2 bg-neutral-200 p-3 overflow-auto">
+    <div class="size-full bg-white rounded-2xl p-6">
+      <!-- 게시글 부분 -->
+      <div class="mb-4">
+        <h2 class="text-xl font-bold">{data.post_title}</h2>
+        <p class="text-sm text-gray-500">{data.post_uploader.user_name} | {data.post_createdDate}</p>
+      </div>
+
+      <div class="mb-6">
+        <p class="tiptap">{@html data.post_content}</p>
+      </div>
+      <!-- 댓글 부분 -->
+      <div class="border-t pt-4">
+        <h3 class="text-lg font-semibold mb-2">💬 댓글 {data.post_comments.length}개</h3>
+        <div class="space-y-4">
+          <!-- 대댓글 구분은 ml-(x)에 따라서 구분 -->
+          <!-- 아예 댓글 컴포넌트로 만들어서 관리 ㄱㄱ -->
+          {#each data.post_comments as comments}
+            <CommonComment data={comments}/>
+          {/each}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script context="module" lang="ts">
+</script>
+
+<script lang="ts">
+  import "$lib/components/tiptap/tiptap.css"
+
+  import CommonComment from '$lib/components/commonComment.svelte';
+  import { testPostData } from '$lib/testPostData';
+
+  import hljs from 'highlight.js';
+  import java from 'highlight.js/lib/languages/java'
+  import 'highlight.js/styles/github-dark.css'
+
+  import { onMount } from 'svelte'
+
+  hljs.registerLanguage('java', java)
+
+  onMount(() => {
+    const blocks = document.querySelectorAll('code')
+    blocks.forEach((block) => {
+      hljs.highlightElement(block as HTMLElement)
+    })
+  })
+
+  const data: App.PostData = testPostData
+</script>

--- a/frontend/src/routes/write/+page.svelte
+++ b/frontend/src/routes/write/+page.svelte
@@ -30,11 +30,15 @@
       </div>
 
       <div class="">
-        <textarea
+        <!--구 내용 입력 (textarea)-->
+        <!--<textarea
           class="w-full border rounded-xl p-2 h-100"
           name="content"
           placeholder="내용을 입력하세요."
         ></textarea>
+        -->
+        <Tiptap bind:content className=" w-full h-150 border-1 border-black p-2 rounded-lg mb-2 overflow-y-scroll"/>
+        <input type="hidden" name="content" value={content} />
       </div>
 
       <div class="flex justify-end">
@@ -52,18 +56,24 @@
 
 <script lang="ts">
   import { goto } from "$app/navigation";
+  import Tiptap from "$lib/components/tiptap/tiptap.svelte";
+  //
+  let content = ''
 
+  // 폼 제출
   const handleSubmit = async (event: SubmitEvent) => {
+
     const form = event.target as HTMLFormElement
     const data = new FormData(form)
 
     // 데이터 정제
     const title = data.get('title')
-    const content = data.get('code')
-    const code = data.get('content')
+    const code = data.get('code')
 
     // 데이터 묶어서 Json 화
     const jsonData = JSON.stringify({ title, content, code })
+
+    console.log(jsonData)
 
     try {
       // 주소로 POST 요청 보내기
@@ -85,7 +95,6 @@
       }
     } catch (err) {
       alert("작성 실패했습니다!")
-      goto('/')
       console.log(err)
     }
   }


### PR DESCRIPTION
- 게시글에 Markdown 문법을 적용했습니다.
  - 게시글 작성 시 실시간으로 Markdown이 적용됩니다.
  - 작성된 텍스트가 Markdown 방식으로 변환되어 보여집니다.
  - 메인 페이지에는 html 태그가 모두 지워지고 남은 길이 128의 문자열만이 보여집니다. 나머지는 ...으로 생략됩니다.
- Markdown 테스트를 위해 /board/-1 페이지를 만들었습니다.
  - 모든 작성글이 이런 식으로 보일 예정입니다.