### PR TITLE
백엔드 부분의 gitignore을 업데이트 했습니다.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# 디폴트 무시된 파일
+/shelf/
+/workspace.xml
+# 에디터 기반 HTTP 클라이언트 요청
+/httpRequests/
+# 환경에 따라 달라지는 Maven 홈 디렉터리
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,72 @@
+# github - gradle의 .gitignore 입니다.
+.gradle
+**/build/
+!src/**/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Avoid ignore Gradle wrappper properties
+!gradle-wrapper.properties
+
+# Cache of project
+.gradletasknamecache
+
+# Eclipse Gradle plugin generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# IntelliJ의 .gitignore입니다.
+
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+*.jar
+!gradle-wrapper.jar
+
+# User local IDEA configuration files
+.idea/
+.run/
+
+# IntelliJ project
+*.iml
+
+# User local IDEA run configurations
+.run/
+
+# Build output & caches for IntelliJ plugin development
+build/
+idea-sandbox/
+.gradle/
+
+## File-based project format:
+*.iws
+
+# IntelliJ
+/out/
+.intellijPlatform
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# JavaScript resources
+src/main/resources/dist/*
+
+# VSCode langserver artifacts
+/bin/
+.DS_Store
+/src/main/kotlin/com/sourcegraph/cody/agent/protocol_generated/*


### PR DESCRIPTION
- #13 이슈를 해결했습니다.
- IntelliJ의 자동 생성 .gitignore을 추가했습니다.
- Github의 Gradle 기본 생성 .gitignore과 IntelliJ의 기본 생성 .gitignore을 조합하여 백엔드의 .gitignore을 추가했습니다.
    - /backend/.gitignore 파일에서 어떤 부분이 어느 곳에서 가져온 내용인지 확인할 수 있습니다. 