### PR TITLE
로그인 페이지가 404 응답을 무시하는 문제를 고쳤습니다.

### DIFF
--- a/frontend/src/routes/u/login/+page.svelte
+++ b/frontend/src/routes/u/login/+page.svelte
@@ -48,7 +48,7 @@
 
       console.log(res)
       
-      if(res.status == 403) {
+      if(res.status == 403 || res.status == 404) {
         alert('아이디 또는 비밀번호가 틀렸습니다!')
         return
       }


### PR DESCRIPTION
- 로그인 실패 시 403 에러만 로그인 실패 알림을 띄우고 멈추는 문제가 있었습니다.
    - 404 에러도 로그인 실패 조건에 포함시켰습니다.